### PR TITLE
Handle crashed redis gracefully (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGE LOG
 ==========
 
-# Changes between 0.0.8 and 0.1.0
+# Changes between 0.0.8 and 0.1.x
 
 ## Disclaimer
 

--- a/example/example.js
+++ b/example/example.js
@@ -12,9 +12,8 @@ cache.on('error', function(error){
 var port = 3000;
 app.listen(port);
 console.log("Server listening on " + port);
-console.log("Server listening on " + port);
 
-// Serve simple page with timestamp
+// Serve simple page with timestamp cached for 5 seconds
 app.get('/',
   cache.route(),
   function (req, res)  {

--- a/lib/ExpressRedisCache.js
+++ b/lib/ExpressRedisCache.js
@@ -21,45 +21,51 @@ module.exports = (function () {
 
     this.options = options || {};
 
-    /** The entry name prefix 
+    /** The entry name prefix
      *
      *  @type String
      */
 
     this.prefix = this.options.prefix || config.prefix;
 
-    /** The host to connect to (default host if null) 
+    /** The host to connect to (default host if null)
      *
      *  @type String
      */
 
     this.host = this.options.host;
 
-    /** The port to connect to (default port if null) 
+    /** The port to connect to (default port if null)
      *
      *  @type Number
      */
 
     this.port = this.options.port;
-    
+
     /** An alias to remove expiration when invoking a route
-     *  
+     *
      *  var cache = new ExpressRedisCache();
      *  cache.route('page', cache.FOREVER); // cache will not expire
      *
      *  @type number
      */
-    
+
     this.FOREVER = -1;
 
+    /** Set expiration time in seconds, default is -1 (No expire)
+     *  @type number
+     */
+
+    this.expire = this.options.expire || this.FOREVER;
+
     /** Whether or not express-redis-cache is connected to Redis
-     *  
+     *
      *  @type Boolean
      */
 
     this.connected = false;
 
-    /** The Redis Client 
+    /** The Redis Client
      *
      *  @type Object (preferably a client from the official Redis module)
      */
@@ -90,7 +96,7 @@ module.exports = (function () {
    *  @method
    *  @description This is a method
    *  @return void{Object}
-   *  @arg {Object} arg - About arg 
+   *  @arg {Object} arg - About arg
    */
 
   ExpressRedisCache.prototype.get = require('./ExpressRedisCache/get');
@@ -100,7 +106,7 @@ module.exports = (function () {
    *  @method
    *  @description This is a method
    *  @return void{Object}
-   *  @arg {Object} arg - About arg 
+   *  @arg {Object} arg - About arg
    */
 
   ExpressRedisCache.prototype.add = require('./ExpressRedisCache/add');
@@ -110,7 +116,7 @@ module.exports = (function () {
    *  @method
    *  @description This is a method
    *  @return void{Object}
-   *  @arg {Object} arg - About arg 
+   *  @arg {Object} arg - About arg
    */
 
   ExpressRedisCache.prototype.del = require('./ExpressRedisCache/del');;
@@ -120,7 +126,7 @@ module.exports = (function () {
    *  @method
    *  @description This is a method
    *  @return void{Object}
-   *  @arg {Object} arg - About arg 
+   *  @arg {Object} arg - About arg
    */
 
   ExpressRedisCache.prototype.route = require('./ExpressRedisCache/route');
@@ -130,7 +136,7 @@ module.exports = (function () {
    *  @method
    *  @description This is a method
    *  @return void{Object}
-   *  @arg {Object} arg - About arg 
+   *  @arg {Object} arg - About arg
    */
 
   ExpressRedisCache.prototype.size = require('./ExpressRedisCache/size');
@@ -140,7 +146,7 @@ module.exports = (function () {
    *  @function
    *  @description This is a function
    *  @return void{Object}
-   *  @arg {Object} arg - About arg 
+   *  @arg {Object} arg - About arg
    */
 
   ExpressRedisCache.init = function (options) {

--- a/lib/ExpressRedisCache/add.js
+++ b/lib/ExpressRedisCache/add.js
@@ -12,7 +12,7 @@ module.exports = (function () {
    *  @callback
    *  @arg {String} name - The cache entry name
    *  @arg {String} body - The cache entry body
-   *  @arg {Object} options - Optional { type: String, expire: Number } 
+   *  @arg {Object} options - Optional { type: String, expire: Number }
    *  @arg {Number} expire - The cache life time in seconds [OPTIONAL]
    *  @arg {Function} callback
    */
@@ -36,35 +36,35 @@ module.exports = (function () {
     domain.run(function () {
 
       /** The new cache entry **/
-      var cache = {
+      var entry = {
         body: body,
         type: options.type || config.type,
         touched: +new Date(),
         expire: options.expire || self.expire
       };
 
-      var size = require('../sizeof')(cache);
+      var size = require('../sizeof')(entry);
 
       var prefix = self.prefix.match(/:$/) ? self.prefix.replace(/:$/, '')
         : self.prefix;
 
       /* Save as a Redis hash */
-      self.client.hmset(prefix + ':' + name, cache,
+      var redisKey = prefix + ':' + name;
+      self.client.hmset(redisKey, entry,
         domain.intercept(function (res) {
-
-          self.emit('message', require('util').format('SET %s ~%d Kb',
-            name, (size / 1024).toFixed(2)));
-          
+          var calculated_size = (size / 1024).toFixed(2);
           /** If @expire then tell Redis to expire **/
-          if ( typeof cache.expire === 'number' && cache.expire > 0 ) {
-            self.client.expire(self.prefix + name, +cache.expire,
+          if ( typeof entry.expire === 'number' && entry.expire > 0 ) {
+            self.client.expire(redisKey, +entry.expire,
               domain.intercept(function () {
-                callback(null, name, cache, res);
+                self.emit('message', require('util').format('SET %s ~%d Kb %d TTL (sec)', redisKey, calculated_size, +entry.expire));
+                callback(null, name, entry, res);
               }));
           }
-
-          else {
-            callback(null, name, cache, res);
+          else
+          {
+            self.emit('message', require('util').format('SET %s ~%d Kb', redisKey, calculated_size));
+            callback(null, name, entry, res);
           }
         }));
     });

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -64,10 +64,10 @@ module.exports = (function () {
         else if ( typeof options[1] === 'number' ) {
           expire = options[1];
         }
-        
+
         /** attempt to get cache **/
         self.get(name, domain.intercept(function (cache) {
-          
+
           /** if it's cached, display cache **/
 
           if ( cache.length ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-redis-cache",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "A module to make Express interact with Redis (create, get, delete). You can automatically cache all your most popular routes in Redis.",
   "main": "index.js",
   "bin": {

--- a/test/ExpressRedisCache/add.js
+++ b/test/ExpressRedisCache/add.js
@@ -21,7 +21,8 @@
   var cache     =   require('../../')({
     prefix: prefix,
     host: host,
-    port: port
+    port: port,
+    expire: 2
   });
 
   describe ( 'add', function () {
@@ -74,6 +75,15 @@
       should(entry.expire).equal(cache.expire);
     });
 
+    it ( 'should expire in ' + cache.expire + ' seconds', function (done) {
+      this.timeout(2500); // allow more time for this test
+      setTimeout(function(){
+        cache.get(_name, function (err, res) {
+          should(err).not.be.ok;
+          res.should.be.an.Array.and.have.a.lengthOf(0);
+          done();
+        });
+      }, cache.expire * 1000);
+    });
   });
-
 })();


### PR DESCRIPTION
* Fixes #17. Middleware won't crash app when redis is crashed/unavailable. Now it emits errors and simulates a cache miss.
* Readme updates
* Example code

