### PR TITLE
Allow multiple deletions using wildcard

### DIFF
--- a/lib/ExpressRedisCache/del.js
+++ b/lib/ExpressRedisCache/del.js
@@ -32,7 +32,7 @@ module.exports = (function () {
 
       /** Tell Redis to delete hash **/
       var redisKey = prefix + ':' + name;
-      self.client.keys(redisKey, function(err, rows) {
+      self.client.keys(redisKey, domain.intercept(function(rows) {
         require('async').each(rows, function(row) {
           self.client.del(row,  domain.intercept(function () {
               self.emit('message', require('util').format('DEL %s', row));

--- a/lib/ExpressRedisCache/del.js
+++ b/lib/ExpressRedisCache/del.js
@@ -32,11 +32,13 @@ module.exports = (function () {
 
       /** Tell Redis to delete hash **/
       var redisKey = prefix + ':' + name;
-      self.client.del(redisKey,
-        domain.intercept(function (deletions) {
-          self.emit('message', require('util').format('DEL %s', redisKey));
-          callback(null, +deletions);
-        }));
+      self.client.keys(redisKey, function(err, rows) {
+        require('async').each(rows, function(row) {
+          self.client.del(row,  domain.intercept(function () {
+              self.emit('message', require('util').format('DEL %s', row));
+            }));  
+        }, callback(null, rows.length));
+      });
     });
   }
 


### PR DESCRIPTION
This will allow multiple deletions on a single call to the `del()` method. So we can use

         cache.del('home.page.*')

instead of

         cache.del('home.page.0');
         cache.del('home.page.1');

The new method is still compatible with the old one.