### PR TITLE
Connect to Redis using password when supplied

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ This will check if there is a cache entry for this route. If not. it will cache 
 
 # Redis connection info
 
-By default, `redis-express-cache` connects to Redis using localhost as host and nothing as port (using Redis default port 6379). To use different port or host, declare them when you require express-redis-cache.
+By default, `redis-express-cache` connects to Redis using localhost as host and nothing as port (using Redis default port 6379). To use different port or host, declare them when you require express-redis-cache. If your Redis server requires password, use the `auth_pass` option.
 
 ```js
 var cache = require('express-redis-cache')({
-  host: String, port: Number
+  host: String, port: Number, auth_pass: REDIS_PASSWORD
   });
 ```
         

--- a/lib/ExpressRedisCache.js
+++ b/lib/ExpressRedisCache.js
@@ -42,6 +42,12 @@ module.exports = (function () {
 
     this.port = this.options.port;
 
+    /** The password of Redis server (optional)
+     *
+     *  @type String
+     */
+     this.auth_pass = this.options.auth_pass;
+
     /** An alias to disable expiration for a specific route
      *
      *  var cache = new ExpressRedisCache();
@@ -70,7 +76,7 @@ module.exports = (function () {
      *  @type Object (preferably a client from the official Redis module)
      */
 
-    this.client = this.options.client || require('redis').createClient(this.port, this.host);
+    this.client = this.options.client || require('redis').createClient(this.port, this.host, { auth_pass: this.auth_pass });
 
     /** If client can emit */
 


### PR DESCRIPTION
Previously, we needed to pass the redis client already authenticated to `express-redis-cache` constructor, something like

```js
    var redis = require('redis').createClient(config.redis.port, config.redis.host, {auth_pass : config.redis.pass});
    var cache = require('express-redis-cache')({client : redis});
```

Now, we can do

```js
     var cache = require('express-redis-cache')({host : config.redis.host, port : config.redis.port, auth_pass : config.redis.pass});
```