### PR TITLE
Update get.js

### DIFF
--- a/lib/ExpressRedisCache/get.js
+++ b/lib/ExpressRedisCache/get.js
@@ -25,6 +25,7 @@ module.exports = (function () {
     domain.run(function () {
 
       if ( typeof name !== 'string' ) {
+        callback = name;
         name = '*';
       }
 


### PR DESCRIPTION
fix callback when the optional name argument is not provided to `.get`