### PR TITLE
Statusexpire

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Easily cache pages of your app using Express and Redis. *Could be used without E
 # Install
 
     npm install express-redis-cache
-    
+
 `express-redis-cache` ships with a CLI utility you can invoke from the console. In order to use it, install `express-redis-cache` globally (might require super user privileges):
 
     npm install -g express-redis-cache
-    
+
 # Upgrade
 
 Read [this](../master/CHANGELOG.md) if you are upgrading from 0.0.8 to 0.1.x,
@@ -32,7 +32,7 @@ app.get('/',
   cache.route(),
   function (req, res)  { ... });
 ```
-    
+
 This will check if there is a cache entry for this route. If not. it will cache it and serve the cache next time route is called.
 
 # Redis connection info
@@ -44,7 +44,7 @@ var cache = require('express-redis-cache')({
   host: String, port: Number, auth_pass: REDIS_PASSWORD
   });
 ```
-        
+
 You can pass a Redis client as well:
 
 ```js
@@ -60,7 +60,7 @@ var client2 = cache({ host: "...", port: "..." });
 ...
 ```
 ## Redis Unavailability
-Should the redis become unavailable, the `express-redis-cache` object will emit errors but will not crash the app. Express.js requests during this time will be bypass cache and will return fresh data. 
+Should the redis become unavailable, the `express-redis-cache` object will emit errors but will not crash the app. Express.js requests during this time will be bypass cache and will return fresh data.
 
 Once the redis recovers, the caching will begin working again. See example code in the `/example` folder.
 
@@ -94,9 +94,9 @@ Also, you can use `res.express_redis_cache_name` to specify the name of the entr
 
 ```js
 app.get('/user/:userid',
-  
+
   // middleware to define cache name
-  
+
   function (req, res, next) {
     // set cache name
     res.express_redis_cache_name = 'user-' + req.params.userid;
@@ -104,15 +104,15 @@ app.get('/user/:userid',
     },
 
   // cache middleware
-  
+
   cache.route(),
-  
+
   // content middleware
-  
+
   function (req, res) {
     res.render('user');
     }
-    
+
   );
 ```
 
@@ -125,16 +125,16 @@ You can also use a previous middleware to set whether or not to use the cache by
 app.get('/user',
 
   // middleware to decide if using cache
-  
+
   function (req, res, next) {
     // Use only cache if user not signed in
     res.use_express_redis_cache = ! req.signedCookies.user;
-    
+
     next();
     }.
-    
+
   cache.route(), // this will be skipped if user is signed in
-  
+
   function (req, res) {
     res.render('user');
     }
@@ -143,7 +143,7 @@ app.get('/user',
 
 # Prefix
 
-All entry names are prepended by a prefix. Prefix is set when calling the Constructor. 
+All entry names are prepended by a prefix. Prefix is set when calling the Constructor.
 
 ```js
 // Set default prefix to "test". All entry names will begin by "test:"
@@ -187,7 +187,7 @@ You can overwrite the default lifetime when calling `route()`:
 app.get('/index.html',
   cache.route({ expire: 5000  }), // cache entry will live 5000 seconds
   function (req, res)  { ... });
-    
+
 // You can also use the number sugar syntax
 cache.route(5000);
 // Or
@@ -195,6 +195,24 @@ cache.route('index', 5000);
 // Or
 cache.route({ prefix: 'test' }, 5000);
 ```
+
+You can also provide a hash of status code / expiration values if you for example want to retry much sooner in failure cases (403/404/500/etc). Status ranges can be specified via `4xx`/`5xx`. You must provide a default value (`xxx`). The most specific rule will be used. For example, if the status code is 200, and there are expirations set for 200, 2xx, and xxx, the expiration for 200 will be used.
+
+```js
+app.get('/index'html',
+  cache.route({
+    expire: {
+      200: 5000,
+      4xx: 10,
+      403: 5000,
+      5xx: 10,
+      xxx: 1
+    }
+  }),
+  function (req, res)  { ... });
+```
+
+You can also specify
 
 # Content Type
 
@@ -267,7 +285,7 @@ cache.on('deprecated', function (deprecated) {
   });
 });
 ```
-    
+
 # The Entry Model
 
 This is the object synopsis we use to represent a cache entry:
@@ -313,19 +331,19 @@ Where `options` is an object that has the following properties:
 # API
 
 The `route` method is designed to integrate easily with Express. You can also define your own caching logics using the other methos of the API shown below.
-    
+
 ## `get` Get cache entries
-    
+
 ```js
 cache.get(/** Mixed (optional) */ query, /** Function( Error, [Entry] ) */ callback );
 ```
-    
+
 To get all cache entries:
 
 ```js
 cache.get(function (error, entries) {
   if ( error ) throw error;
-  
+
   entries.forEach(console.log.bind(console));
 });
 ```
@@ -347,9 +365,9 @@ You can use wildcard:
 ```js
 cache.get('user*', function (error, entries) {});
 ```
-    
+
 ## `add` Add a new cache entry
-    
+
 ```js
 cache.add(/** String */ name, /** String */ body, /** Object (optional) **/ options, /** Function( Error, Entry ) */ callback )
 ```
@@ -358,7 +376,7 @@ Where options is an object that can have the following properties:
 
 - **expire** `Number` (lifetime of entry in seconds)
 - **type** `String` (the content-type)
-    
+
 Example:
 
 ```js
@@ -367,7 +385,7 @@ cache.add('user:info', JSON.stringify({ id: 1, email: 'john@doe.com' }), { expir
 ```
 
 ## `del` Delete a cache entry
-    
+
 ```js
 cache.del(/** String */ name, /** Function ( Error, Number deletions ) */ callback);
 ```
@@ -375,11 +393,11 @@ cache.del(/** String */ name, /** Function ( Error, Number deletions ) */ callba
 You can use wildcard (*) in name.
 
 ## `size` Get cache size for all entries
-    
+
 ```js
 cache.size(/** Function ( Error, Number bytes ) */);
 ```
-    
+
 # Command line
 
 We ship with a CLI. You can invoke it like this: `express-redis-cache`

--- a/lib/ExpressRedisCache/expire.js
+++ b/lib/ExpressRedisCache/expire.js
@@ -1,0 +1,53 @@
+module.exports = (function () {
+
+  'use strict';
+
+  // Convert HTTP status codes into 1xx, 2xx, 3xx, 4xx, 5xx
+  function maskStatus (statusCode) {
+    return String(statusCode).match(/(\d)\d\d/)[1] + 'xx';
+  }
+
+  // Turn the policy argument into a function that consumes a
+  // status code and returns the expiration value
+  function createExpirationPolicy (options) {
+    if (typeof options !== 'object' && typeof options !== 'number') {
+      throw new Error('expire option cannot be type ' + typeof options);
+    }
+
+    if ( typeof options === 'number' ) {
+      options = {
+        'xxx': options
+      };
+    }
+
+    for (var k in options) {
+      if (!k.match(/xxx/i) && !k.match(/[1-5]xx/i) && !k.match(/[1-5][0-9]{2}/)) {
+        throw new Error('invalid statusCode ' + k);
+      }
+      if (typeof options[k] !== 'number') {
+        throw new Error('invalid expiration for statusCode ' + k);
+      }
+      var v = options[k];
+      delete options[v];
+      options[k.toLowerCase()] = v;
+    }
+
+    if (!options.hasOwnProperty('xxx')) {
+      throw new Error('no default expiration provided');
+    }
+
+    return function (statusCode) {
+      if (options.hasOwnProperty(statusCode)) {
+        return options[statusCode];
+      }
+      else if (options.hasOwnProperty(maskStatus(statusCode))) {
+        return options[maskStatus(statusCode)];
+      }
+      else {
+        return options.xxx;
+      }
+    };
+  }
+
+  return createExpirationPolicy;
+})();

--- a/lib/ExpressRedisCache/expire.js
+++ b/lib/ExpressRedisCache/expire.js
@@ -14,6 +14,8 @@ module.exports = (function () {
       throw new Error('expire option cannot be type ' + typeof options);
     }
 
+    // Internally store expiration as an object,
+    // so if a number is provided, use that as the default
     if ( typeof options === 'number' ) {
       options = {
         'xxx': options
@@ -21,28 +23,35 @@ module.exports = (function () {
     }
 
     for (var k in options) {
+      // Ensure that keys are in the form xxx, 4xx, or 400
       if (!k.match(/xxx/i) && !k.match(/[1-5]xx/i) && !k.match(/[1-5][0-9]{2}/)) {
         throw new Error('invalid statusCode ' + k);
       }
+      // Ensure that the expiration values are numbers
       if (typeof options[k] !== 'number') {
         throw new Error('invalid expiration for statusCode ' + k);
       }
+      // Convert keys to lower case
       var v = options[k];
       delete options[v];
       options[k.toLowerCase()] = v;
     }
 
+    // Ensure that there is a default so we can always return a value
     if (!options.hasOwnProperty('xxx')) {
       throw new Error('no default expiration provided');
     }
 
     return function (statusCode) {
+      // Look for exact status code matches first
       if (options.hasOwnProperty(statusCode)) {
         return options[statusCode];
       }
+      // Test for a 4xx style match
       else if (options.hasOwnProperty(maskStatus(statusCode))) {
         return options[maskStatus(statusCode)];
       }
+      // Fallback to the default expiration value
       else {
         return options.xxx;
       }

--- a/lib/ExpressRedisCache/route.js
+++ b/lib/ExpressRedisCache/route.js
@@ -31,16 +31,16 @@ module.exports = (function () {
 
     var options = arguments;
 
-    /** The domain handler 
-     *  
-     *  @type Domain 
+    /** The domain handler
+     *
+     *  @type Domain
      */
 
     var domain = require('domain').create();
 
-    /** The domain error handler 
-     *  
-     *  @type Domain 
+    /** The domain error handler
+     *
+     *  @type Domain
      */
 
     domain.on('error', function (error) {
@@ -48,7 +48,6 @@ module.exports = (function () {
     });
 
     domain.run(function () {
-
       // Build the middleware function
 
       /**
@@ -117,18 +116,21 @@ module.exports = (function () {
          *  @type Number
          *  @default this.expire
          */
-
         var expire = self.expire;
-        if ( typeof options[0] === 'object' && typeof options[0].expire === 'number' ) {
-          expire = options[0].expire;
+        if ( typeof options[0] === 'object' ) {
+          if ( typeof options[0].expire === 'number' || typeof options[0].expire === 'object' ) {
+            expire = options[0].expire;
+          }
         }
 
         if ( typeof options[0] === 'number' ) {
           expire = options[0];
         }
-        else if ( typeof options[1] === 'number' ) {
+        else if ( typeof options[1] === 'number' || typeof options[1] === 'object') {
           expire = options[1];
         }
+
+        var expirationPolicy = require('./expire')(expire);
 
         /** attempt to get cache **/
         self.get(name, domain.bind(function (error, cache) {
@@ -177,7 +179,7 @@ module.exports = (function () {
                 /** Create the new cache **/
                 self.add(name, body, {
                     type: this._headers['content-type'],
-                    expire: expire
+                    expire: expirationPolicy(res.statusCode)
                   },
                   domain.intercept(function (name, cache) {}));
               }

--- a/test/expire.js
+++ b/test/expire.js
@@ -1,0 +1,127 @@
+(function () {
+  'use strict';
+
+  var mocha     =   require('mocha');
+  var should    =   require('should');
+
+  var createExpirationPolicy = require('../lib/ExpressRedisCache/expire');
+
+  describe ( 'expire', function () {
+
+    it ( 'should be a function', function () {
+      createExpirationPolicy.should.be.a.Function;
+    });
+
+    it ( 'should accept a number', function () {
+      createExpirationPolicy(1).should.be.a.Function;
+    });
+
+    it ( 'should accept an object', function () {
+      createExpirationPolicy({
+          'xxx': -1,
+        }).should.be.a.Function;
+    });
+
+    it ( 'should require an argument', function () {
+      createExpirationPolicy.should.throw();
+    });
+
+    it ( 'should not accept a boolean', function () {
+      (function () {
+        createExpirationPolicy(true);
+      }).should.throw();
+    });
+
+    it ( 'should require a default (xxx) expiration', function () {
+      (function () {
+        createExpirationPolicy({
+          '1xx': 1,
+          '2xx': 2
+        });
+      }).should.throw();
+    });
+
+    it ( 'should only accept two orders of wildcards', function () {
+      (function () {
+        createExpirationPolicy({
+          'xxx': -1,
+          '33x': 1
+        });
+      }).should.throw();
+    });
+
+    it ( 'should only accept number values for status code specific values', function () {
+      (function () {
+        createExpirationPolicy({
+          'xxx': -1,
+          '33x': true
+        });
+      }).should.throw();
+    });
+
+    it ( 'should only accept valid status code keys', function () {
+      (function () {
+        createExpirationPolicy({
+          'xxx': -1,
+          '6xx': 1
+        });
+      }).should.throw();
+      (function () {
+        createExpirationPolicy({
+          'xxx': -1,
+          '600': 1
+        });
+      }).should.throw();
+      (function () {
+        createExpirationPolicy({
+          'xxx': -1,
+          '6': 1
+        });
+      }).should.throw();
+    })
+
+    it ( 'should return the specified value for all status codes', function () {
+      createExpirationPolicy(-1)(200).should.equal(-1);
+      createExpirationPolicy(1)(300).should.equal(1);
+      createExpirationPolicy(22)(403).should.equal(22)
+      createExpirationPolicy(333)(404).should.equal(333)
+      createExpirationPolicy(4444)(500).should.equal(4444)
+    });
+
+    it ( 'should return the appropriate value for status codes', function () {
+      var policy = createExpirationPolicy({
+        'xxx': -1,
+        '1xx': 1,
+        '100': 100,
+        '2xx': 2,
+        '200': 200,
+        '4xx': 4,
+        '400': 400,
+        '403': 403,
+        '404': 404,
+        '5xx': 5,
+        '500': 500
+      });
+      policy(500).should.equal(500);
+      policy(501).should.equal(5);
+      policy(404).should.equal(404);
+      policy(403).should.equal(403);
+      policy(400).should.equal(400);
+      policy(480).should.equal(4);
+      policy(200).should.equal(200);
+      policy(201).should.equal(2);
+      policy(100).should.equal(100);
+      policy(101).should.equal(1);
+      policy(300).should.equal(-1);
+    });
+
+    it ( 'should treat status code keys as case insensitive', function () {
+      var policy = createExpirationPolicy({
+        '1XX': 1,
+        'xXx': 55
+      });
+      policy(101).should.equal(1);
+      policy(200).should.equal(55);
+    });
+  });
+})();

--- a/test/route.js
+++ b/test/route.js
@@ -29,6 +29,7 @@
 
   /** Emulate res **/
   var res = {
+    statusCode: 200,
     send: function (body) {
 
     },
@@ -184,6 +185,7 @@ module.exports = function (cb) {
 
             /** Emulate res **/
             var res = {
+              statusCode: 200,
               send: function (body) {
                 assert('it should be the same message', body === entry.body);
 


### PR DESCRIPTION
adding support for expire values of objects, which are status code/expiration mappings (still supports just a number value).

ie,
```js
{
  '200': 1000,
  '4xx': 10,
  '403': 100000,
  'xxx': 100
}
```