### PR TITLE
changed . to , in middleware conditional caching example

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ app.get('/user',
     res.use_express_redis_cache = ! req.signedCookies.user;
 
     next();
-    }.
+  },
 
   cache.route(), // this will be skipped if user is signed in
 


### PR DESCRIPTION
I could be wrong, but I believe this is supposed to be a comma not a dot in the middleware conditional caching example? thanks! love this thing.